### PR TITLE
Feature/other_functions/negate

### DIFF
--- a/build/cflags.current
+++ b/build/cflags.current
@@ -1,1 +1,1 @@
--Wall -Werror -Wextra -std=c11 -pedantic -I./headers -lm
+-Wall -Werror -Wextra -std=c11 -pedantic -I./include -lm

--- a/include/s21_decimal.h
+++ b/include/s21_decimal.h
@@ -234,8 +234,8 @@ int s21_truncate(s21_decimal value, s21_decimal *result);
  * @param value Decimal number to negate
  * @param result Pointer to store the negated value
  * @return Error code: `0` (OK), `1` (error)
- * @author
- * @date
+ * @author Amfir (s21: tyananai)
+ * @date April 17, 2025
  */
 int s21_negate(s21_decimal value, s21_decimal *result);
 

--- a/include/s21_suites.h
+++ b/include/s21_suites.h
@@ -5,5 +5,6 @@
 
 // TODO: don't forget to add new suits here...
 Suite *s21_helpers_suite(void);
+Suite *s21_negate_suite(void);
 
 #endif /* S21_SUITES_H */

--- a/src/s21_negate.c
+++ b/src/s21_negate.c
@@ -1,0 +1,12 @@
+#include "../include/s21_decimal.h"
+
+int s21_negate(s21_decimal value, s21_decimal *result) {
+  if (!result) {
+    return 1;
+  }
+
+  *result = value;
+  result->bits[3] ^= (1u << 31);
+
+  return 0;
+}

--- a/src/s21_negate.c
+++ b/src/s21_negate.c
@@ -2,11 +2,11 @@
 
 int s21_negate(s21_decimal value, s21_decimal *result) {
   if (!result) {
-    return 1;
+    return S21_ERROR;
   }
 
   *result = value;
   result->bits[3] ^= (1u << 31);
 
-  return 0;
+  return S21_SUCCESS;
 }

--- a/tests/main.c
+++ b/tests/main.c
@@ -11,6 +11,8 @@ int main(void) {
 
   //  TODO(all): add after comment your suits...
 
+  srunner_add_suite(sr, s21_negate_suite());
+
   //  Check for CK_RUN_SUITE and set a custom log file
   const char *suite = getenv("CK_RUN_SUITE");
   if (suite && strlen(suite) > 0) {

--- a/tests/test_negate.c
+++ b/tests/test_negate.c
@@ -1,0 +1,90 @@
+#include "../include/s21_decimal.h"
+#include "../include/s21_suites.h"
+
+START_TEST(test_negate_positive) {
+  s21_decimal a = {{123, 0, 0, 0}};
+  s21_decimal res;
+  ck_assert_int_eq(s21_negate(a, &res), 0);
+  ck_assert_int_eq(res.bits[3] >> 31, 1);
+  ck_assert_int_eq(res.bits[0], 123);
+}
+END_TEST
+
+START_TEST(test_negate_negative) {
+  s21_decimal a = {{123, 0, 0, 0x80000000}};
+  s21_decimal res;
+  ck_assert_int_eq(s21_negate(a, &res), 0);
+  ck_assert_int_eq(res.bits[3] >> 31, 0);
+  ck_assert_int_eq(res.bits[0], 123);
+}
+END_TEST
+
+START_TEST(test_negate_zero_positive) {
+  s21_decimal a = {{0, 0, 0, 0}};
+  s21_decimal res;
+  ck_assert_int_eq(s21_negate(a, &res), 0);
+  ck_assert_int_eq(res.bits[0], 0);
+  ck_assert_int_eq(res.bits[1], 0);
+  ck_assert_int_eq(res.bits[2], 0);
+}
+END_TEST
+
+START_TEST(test_negate_zero_negative) {
+  s21_decimal a = {{0, 0, 0, 0x80000000}};
+  s21_decimal res;
+  ck_assert_int_eq(s21_negate(a, &res), 0);
+  ck_assert_int_eq(res.bits[0], 0);
+  ck_assert_int_eq(res.bits[1], 0);
+  ck_assert_int_eq(res.bits[2], 0);
+  ck_assert_int_eq(res.bits[3] >> 31, 0);
+}
+END_TEST
+
+START_TEST(test_negate_null_result) {
+  s21_decimal a = {{123, 0, 0, 0}};
+  ck_assert_int_eq(s21_negate(a, NULL), 1);
+}
+END_TEST
+
+START_TEST(test_negate_scale_preserved) {
+  s21_decimal a = {{1000, 0, 0, 0}};
+  a.bits[3] = (2 << 16);
+  s21_decimal res;
+  ck_assert_int_eq(s21_negate(a, &res), 0);
+  ck_assert_int_eq((res.bits[3] >> 16) & 0xFF, 2);
+  ck_assert_int_eq(res.bits[3] >> 31, 1);
+}
+END_TEST
+
+START_TEST(test_negate_max_value) {
+  s21_decimal a = {{0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0}};
+  s21_decimal res;
+  ck_assert_int_eq(s21_negate(a, &res), 0);
+  ck_assert_int_eq(res.bits[3] >> 31, 1);
+}
+END_TEST
+
+START_TEST(test_negate_min_value) {
+  s21_decimal a = {{0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x80000000}};
+  s21_decimal res;
+  ck_assert_int_eq(s21_negate(a, &res), 0);
+  ck_assert_int_eq(res.bits[3] >> 31, 0);
+}
+END_TEST
+
+Suite *s21_negate_suite(void) {
+  Suite *s = suite_create("negate");
+  TCase *tc = tcase_create("core");
+
+  tcase_add_test(tc, test_negate_positive);
+  tcase_add_test(tc, test_negate_negative);
+  tcase_add_test(tc, test_negate_zero_positive);
+  tcase_add_test(tc, test_negate_zero_negative);
+  tcase_add_test(tc, test_negate_null_result);
+  tcase_add_test(tc, test_negate_scale_preserved);
+  tcase_add_test(tc, test_negate_max_value);
+  tcase_add_test(tc, test_negate_min_value);
+
+  suite_add_tcase(s, tc);
+  return s;
+}


### PR DESCRIPTION
## Function Review: `s21_negate`

The 's21_negate` function takes an input value and returns a separate object representing the same number with the opposite sign.

### Parameters
- `value` — the source number (`s21_decimal`).
- `result` — pointer to store the resulting number with the inverted sign.

### Return Value
- `0` — successful execution.
- `1` — error (e.g., invalid `result` pointer).

### Implementation Notes
- The function does not modify the original `value`, only the `result`.
- Negation is implemented by flipping the sign bit (31st bit of the highest word).
- The scale (exponent) and the magnitude of the number are preserved.